### PR TITLE
Small fix to remove deprecation warnings

### DIFF
--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -250,10 +250,10 @@ export function registerWrappers() {
       token.vision.los.origin.b = token.vision.los.origin.t = losHeight;
     }
     if (canvas.effects.lightSources.has(sourceId)) {
-      token.light.los.origin.b = token.light.los.origin.t = losHeight;
+      token.light.shape.origin.b = token.light.shape.origin.t = losHeight;
     }
     if (canvas.effects.visionSources.has(sourceId) && (token.vision.los.origin.b !== losHeight || token.vision.los.origin.t !== losHeight)
-      || canvas.effects.lightSources.has(sourceId) && (token.light.los.origin.b !== losHeight || token.light.los.origin.t !== losHeight)) {
+      || canvas.effects.lightSources.has(sourceId) && (token.light.shape.origin.b !== losHeight || token.light.shape.origin.t !== losHeight)) {
       token.updateSource({ defer: true });
       WallHeight.schedulePerceptionUpdate();
     }


### PR DESCRIPTION
It seems that `light.los` is marked as deprecated since v11 causing tokens with an active light source to throw alot of warnings:

![image](https://github.com/theripper93/wall-height/assets/137942782/234fb2ea-c54f-41f9-a0b5-a3fb25721644)

This seems to lead to noticable performance problems for some users.